### PR TITLE
Properly report test failure output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Improved output on inner test failure
+
+
 0.1.4
 -----
 - Fixed deadlock for tests with excessive output

--- a/core/src/cmdline.rs
+++ b/core/src/cmdline.rs
@@ -234,6 +234,7 @@ mod test {
     use super::*;
 
     use std::borrow::ToOwned;
+    use std::process::ExitCode;
 
     use crate::fork;
 
@@ -281,7 +282,7 @@ mod test {
     fn define_args_via_env() {
         // Run in subprocess so we can change the environment without
         // affecting other tests.
-        fork(fork_id!(), fork_test_name!(define_args_via_env), || {
+        let status = fork(fork_id!(), fork_test_name!(define_args_via_env), || {
             // SAFETY: We are running in a single threaded processes
             //         after we worked.
             unsafe { env::set_var("TEST_FORK_FLAG_X", "pass") };
@@ -300,6 +301,8 @@ mod test {
             assert_eq!("", &strip("test --bar").unwrap());
             assert_eq!("", &strip("test --baz --notaflag").unwrap());
         })
-        .unwrap()
+        .unwrap();
+
+        assert_eq!(status, ExitCode::SUCCESS);
     }
 }

--- a/core/src/fork.rs
+++ b/core/src/fork.rs
@@ -31,13 +31,10 @@ const OCCURS_ENV: &str = "TEST_FORK_OCCURS";
 const OCCURS_TERM_LENGTH: usize = 17; /* ':' plus 16 hexits */
 
 
-fn supervise_child(child: Child) {
+/// Supervise a child process and indicate its success/failure to the
+/// caller.
+fn supervise_child(child: Child) -> ExitCode {
     let output = child.wait_with_output().expect("failed to wait for child");
-    assert!(
-        output.status.success(),
-        "child exited unsuccessfully with {}",
-        output.status,
-    );
 
     // Make sure to forward output we captured to our own output, using
     // print! and eprint! macros, which hook into the test output
@@ -50,6 +47,12 @@ fn supervise_child(child: Child) {
     if !output.stderr.is_empty() {
         let s = String::from_utf8_lossy(&output.stderr);
         eprint!("{s}");
+    }
+
+    if output.status.success() {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
     }
 }
 
@@ -74,10 +77,9 @@ fn supervise_child(child: Child) {
 /// `test_name` must exactly match the full path of the test function being
 /// run.
 ///
-/// If `test` panics, the child process exits with a failure code immediately
-/// rather than let the panic propagate out of the `fork()` call.
+/// The returned `ExitCode` indicates the success/failure of `test`.
 ///
-/// ## Panics
+/// # Panics
 ///
 /// Panics if the environment indicates that there are already at least 16
 /// levels of fork nesting.
@@ -86,7 +88,7 @@ fn supervise_child(child: Child) {
 /// the current executable.
 ///
 /// Panics if any argument to the current process is not valid UTF-8.
-pub fn fork<F, T>(fork_id: &str, test_name: &str, test: F) -> Result<()>
+pub fn fork<F, T>(fork_id: &str, test_name: &str, test: F) -> Result<ExitCode>
 where
     // NB: We use `Fn` here, because `FnMut` and `FnOnce` would allow
     //     for modification of captured variables, but that will not
@@ -110,7 +112,12 @@ where
 /// This function is similar to [`fork`], except that it allows for data
 /// exchange with the child process.
 #[expect(clippy::panic_in_result_fn, clippy::unwrap_in_result)]
-pub fn fork_in_out<F, T>(fork_id: &str, test_name: &str, test: F, data: &mut [u8]) -> Result<()>
+pub fn fork_in_out<F, T>(
+    fork_id: &str,
+    test_name: &str,
+    test: F,
+    data: &mut [u8],
+) -> Result<ExitCode>
 where
     F: Fn(&mut [u8]) -> T,
     T: Termination,
@@ -257,14 +264,16 @@ mod test {
 
     #[test]
     fn fork_basically_works() {
-        fork_int(
+        let status = fork_int(
             "fork::test::fork_basically_works",
             fork_id!(),
             |_| (),
             supervise_child,
             || println!("hello from child"),
         )
-        .unwrap()
+        .unwrap();
+
+        assert_eq!(status, ExitCode::SUCCESS);
     }
 
     #[test]
@@ -295,11 +304,11 @@ mod test {
             "fork::test::child_aborted_if_panics",
             fork_id!(),
             |_| (),
-            |mut child| child.wait().unwrap(),
+            |mut child| child.wait().unwrap().code().unwrap(),
             || panic!("testing a panic, nothing to see here"),
         )
         .unwrap();
-        assert_eq!(70, status.code().unwrap());
+        assert_eq!(status, 70);
     }
 
     /// Check that we can exchange data with the child process.
@@ -307,7 +316,7 @@ mod test {
     fn data_exchange() {
         let mut data = [1, 2, 3, 4, 5];
 
-        let () = fork_in_out(
+        let status = fork_in_out(
             fork_id!(),
             "fork::test::data_exchange",
             |data| {
@@ -319,5 +328,6 @@ mod test {
         .unwrap();
 
         assert_eq!(data, [2, 3, 4, 5, 6]);
+        assert_eq!(status, ExitCode::SUCCESS);
     }
 }

--- a/core/src/procmac.rs
+++ b/core/src/procmac.rs
@@ -10,6 +10,7 @@ use proc_macro2::TokenStream as Tokens;
 use quote::quote;
 use quote::ToTokens as _;
 
+use syn::parse_quote;
 use syn::Attribute;
 use syn::Error;
 use syn::FnArg;
@@ -71,6 +72,15 @@ fn is_attribute_kind(kind: Kind, attr: &Attribute) -> bool {
 }
 
 
+/// Check whether the given attribute is a `#[should_panic]` attribute.
+fn is_should_panic(attr: &Attribute) -> bool {
+    match &attr.meta {
+        syn::Meta::Path(path) => path.is_ident("should_panic"),
+        _ => false,
+    }
+}
+
+
 /// Testable implementation of the `#[test]` attribute's core logic.
 pub fn try_test(attr: Tokens, input_fn: ItemFn) -> Result<Tokens> {
     let has_test = input_fn
@@ -104,10 +114,42 @@ fn try_test_inner(attr: Tokens, input_fn: ItemFn, inner_test: Tokens) -> Result<
     let test_name = sig.ident.clone();
     let mut body_fn_sig = sig.clone();
     body_fn_sig.ident = Ident::new("body_fn", Span::call_site());
-    // Our tests currently basically have to return (), because we don't
-    // have a good way of conveying the result back from the child
-    // process.
-    sig.output = ReturnType::Default;
+
+    let fork_call = quote! {
+        ::test_fork::test_fork_core::fork(
+            ::test_fork::test_fork_core::fork_id!(),
+            ::test_fork::test_fork_core::fork_test_name!(#test_name),
+            body_fn as fn() -> _,
+        ).expect("forking test failed")
+    };
+
+    let (output, tail) = if attrs.iter().any(is_should_panic) {
+        // `#[should_panic]` requires the test function to return `()`,
+        // and libtest decides pass/fail based on whether the function
+        // panics. The actual test body runs in the forked child, so we
+        // translate a failing child (which includes a panicking one)
+        // back into a panic here, which libtest's `#[should_panic]`
+        // handling then observes.
+        // TODO: This isn't super clean, because we could conceivably
+        //       report an error for other reasons or panic due to a
+        //       test-fork setup failure, but it seems the best we can
+        //       do?
+        (
+            ReturnType::Default,
+            quote! {
+                ::std::assert_eq!(#fork_call, ::std::process::ExitCode::SUCCESS);
+            },
+        )
+    } else {
+        // Our test "shims" otherwise map actual test success/failure to
+        // a mere `ExitCode`. This way, we introduce the least
+        // perturbance compared to, say, `std::process::exit` or
+        // `panic`, both of which would be caught by libtest's harness
+        // and result in additional output (confusing error messages or
+        // additional backtraces, respectively).
+        (parse_quote!(-> ::std::process::ExitCode), fork_call)
+    };
+    sig.output = output;
 
     let augmented_test = quote! {
         #inner_test
@@ -116,11 +158,7 @@ fn try_test_inner(attr: Tokens, input_fn: ItemFn, inner_test: Tokens) -> Result<
             #body_fn_sig
             #block
 
-            ::test_fork::test_fork_core::fork(
-                ::test_fork::test_fork_core::fork_id!(),
-                ::test_fork::test_fork_core::fork_test_name!(#test_name),
-                body_fn as fn() -> _,
-            ).expect("forking test failed")
+            #tail
         }
     };
 
@@ -183,7 +221,7 @@ fn try_bench_inner(attr: Tokens, input_fn: ItemFn, inner_bench: Tokens) -> Resul
     let test_name = sig.ident.clone();
     let mut body_fn_sig = sig.clone();
     body_fn_sig.ident = Ident::new("body_fn", Span::call_site());
-    sig.output = ReturnType::Default;
+    sig.output = parse_quote!(-> ::std::process::ExitCode);
 
     let augmented_bench = quote! {
         #inner_bench

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -71,6 +71,20 @@ fn snapshot_test_attr() {
     assert_snapshot!(output);
 }
 
+/// Check expansion of a `#[test_fork::test]` test that is additionally
+/// annotated with `#[should_panic]`.
+#[test]
+fn snapshot_test_should_panic() {
+    let output = expand(parse_quote! {
+        #[test_fork::test]
+        #[should_panic]
+        fn it_panics() {
+            panic!("boom");
+        }
+    });
+    assert_snapshot!(output);
+}
+
 /// Check expansion of a plain `#[test_fork::fork]` test.
 #[test]
 fn snapshot_fork_attr() {

--- a/core/tests/snapshots/snapshots__snapshot_bench_attr.snap
+++ b/core/tests/snapshots/snapshots__snapshot_bench_attr.snap
@@ -3,7 +3,7 @@ source: core/tests/snapshots.rs
 expression: output
 ---
 #[::core::prelude::v1::bench]
-fn bench_it(b: &mut Bencher) {
+fn bench_it(b: &mut Bencher) -> ::std::process::ExitCode {
     fn body_fn(b: &mut Bencher) {
         let () = b.iter(|| 2 + 2);
     }

--- a/core/tests/snapshots/snapshots__snapshot_fork_attr.snap
+++ b/core/tests/snapshots/snapshots__snapshot_fork_attr.snap
@@ -3,7 +3,7 @@ source: core/tests/snapshots.rs
 expression: output
 ---
 #[test]
-fn it_works() {
+fn it_works() -> ::std::process::ExitCode {
     fn body_fn() {
         assert_eq!(2 + 2, 4);
     }

--- a/core/tests/snapshots/snapshots__snapshot_test_attr.snap
+++ b/core/tests/snapshots/snapshots__snapshot_test_attr.snap
@@ -3,7 +3,7 @@ source: core/tests/snapshots.rs
 expression: output
 ---
 #[::core::prelude::v1::test]
-fn it_works() {
+fn it_works() -> ::std::process::ExitCode {
     fn body_fn() {
         assert_eq!(2 + 2, 4);
     }

--- a/core/tests/snapshots/snapshots__snapshot_test_should_panic.snap
+++ b/core/tests/snapshots/snapshots__snapshot_test_should_panic.snap
@@ -1,0 +1,16 @@
+---
+source: core/tests/snapshots.rs
+expression: output
+---
+#[::core::prelude::v1::test]
+#[should_panic]
+fn it_panics() {
+    fn body_fn() {
+        panic!("boom");
+    }
+    ::std::assert_eq!(
+        ::test_fork::test_fork_core::fork(::test_fork::test_fork_core::fork_id!(),
+        ::test_fork::test_fork_core::fork_test_name!(it_panics), body_fn as fn () -> _,)
+        .expect("forking test failed"), ::std::process::ExitCode::SUCCESS
+    );
+}

--- a/tests/fail/fork-env-mut-capture.rs
+++ b/tests/fail/fork-env-mut-capture.rs
@@ -1,5 +1,7 @@
-// Copyright (C) 2025 Daniel Mueller <deso@posteo.net>
+// Copyright (C) 2025-2026 Daniel Mueller <deso@posteo.net>
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+use std::process::ExitCode;
 
 use test_fork_core::fork;
 use test_fork_core::fork_id;
@@ -10,10 +12,12 @@ use test_fork_core::fork_id;
 fn env_mut_capture() {
     let mut x = 0;
 
-    fork(fork_id!(), "env_mut_capture", || {
+    let status = fork(fork_id!(), "env_mut_capture", || {
         x += 1;
     })
-    .unwrap()
+    .unwrap();
+
+    assert_eq!(status, ExitCode::SUCCESS);
 }
 
 fn main() {}

--- a/tests/fail/fork-env-mut-capture.stderr
+++ b/tests/fail/fork-env-mut-capture.stderr
@@ -1,12 +1,10 @@
 error[E0594]: cannot assign to `x`, as it is a captured variable in a `Fn` closure
-  --> tests/fail/fork-env-mut-capture.rs:14:9
+  --> tests/fail/fork-env-mut-capture.rs:16:9
    |
-10 | fn env_mut_capture() {
-   |    ---------------  - change this to return `FnMut` instead of `Fn`
-11 |     let mut x = 0;
+13 |     let mut x = 0;
    |         ----- `x` declared here, outside the closure
-12 |
-13 |     fork(fork_id!(), "env_mut_capture", || {
-   |                                         -- in this closure
-14 |         x += 1;
+14 |
+15 |     let status = fork(fork_id!(), "env_mut_capture", || {
+   |                                                      -- in this closure
+16 |         x += 1;
    |         ^^^^^^ cannot assign


### PR DESCRIPTION
When a test fails due to a panic (which traditionally has been the main way to communicate failure), we only manifest that with the rather nondescript message:
> child exited unsuccessfully with exit status: 70

Most importantly, actual test output is not surfaced.

Fix this state of affairs by making all our generated test shims emit an ExitCode reflecting the child's success/failure. Because we no longer panic on the child's status ourselves, output is displayed as it should.

Reported-by: Piotr Kołaczkowski <pkolaczk@gmail.com>
Closes: #6